### PR TITLE
cross build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
+PKG_CONFIG ?= pkg-config
 CFLAGS := -g -O2 -Wall
-LDLIBS := $(shell pkg-config --cflags --libs liblz4)
+LDLIBS := $(shell $(PKG_CONFIG) --cflags --libs liblz4)
 
 lz4jsoncat: lz4jsoncat.c
 


### PR DESCRIPTION
Allow non-hard-coded pkg-config, to make make lz4json cross buildable.

Patch by Helmut Grohne — [Debian bug #931020](https://bugs.debian.org/931020).