### PR TITLE
Make it possible to compile lz4json cleanly on Mac OS X and NetBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,18 @@
 PKG_CONFIG ?= pkg-config
-CFLAGS := -g -O2 -Wall
-LDLIBS := $(shell $(PKG_CONFIG) --cflags --libs liblz4)
+LOCALBASE ?= /opt/local
+LOCALBASE != if [ -d "$(LOCALBASE)" ]; then echo "$(LOCALBASE)"; \
+	elif [ -d /opt/local	]; then echo /opt/local	;\
+	elif [ -d /usr/pkg	]; then echo /usr/pkg	;\
+	fi
+CFLAGS += -g -O2 -Wall
+CFLAGS += -I/usr/local/include -I$(LOCALBASE)/include
+
+LIBLZ4 = which $(PKG_CONFIG) 2>&1 1>/dev/null \
+	&& $(PKG_CONFIG) --cflags --libs liblz4 2>/dev/null \
+	|| echo -llz4
+LDLIBS ?= $(shell $(LIBLZ4))	# gmake
+LDLIBS != $(LIBLZ4)		# bsdmake and newer gmake
+LDFLAGS += -L/usr/local/lib -L$(LOCALBASE)/lib
 
 lz4jsoncat: lz4jsoncat.c
 

--- a/lz4jsoncat.c
+++ b/lz4jsoncat.c
@@ -28,7 +28,17 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdint.h>
+
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+#define htole32(x) OSSwapHostToLittleInt32(x)
+
+#else /* !__APPLE__ */
+
 #include <endian.h>
+
+#endif /* __APPLE__ */
 
 #include "lz4.h"
 


### PR DESCRIPTION
This pull request has two commits that together make it possible to compile lz4jsoncat cleanly on both Mac OS X (w/ MacPorts) and NetBSD, with make/gmake and bsdmake/make on each system (4 total combinations tested).  Below is a copy of each of the commit messages.

---

1
=

lz4jsoncat.c: define htole32() on Mac OS X

* Addresses the following error message:

```
lz4jsoncat.c:31:10: fatal error: 'endian.h' file not found
         ^
1 error generated.
make: *** [lz4jsoncat] Error 1
```

* Solution hinted at https://gist.github.com/yinyin/2027912.

* Note that the <endian.h> file is present on OS X as <machine/endian.h>,
  but including it is fruitless, as it doesn't define htole32():

```
lz4jsoncat.c:62:18: warning: implicit declaration of function 'htole32' is invalid in C99 [-Wimplicit-function-declaration]
                size_t outsz = htole32(*(uint32_t *) (map + 8));
                               ^
1 warning generated.
Undefined symbols for architecture x86_64:
  "_htole32", referenced from:
      _main in lz4jsoncat-8ea51e.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [lz4jsoncat] Error 1
```

---

2
=

lz4json Makefile: make it work on Mac OS X w/ MacPorts and BSD

* These changes make it possible to compile lz4jsoncat on Mac OS X
  with archivers/lz4 installed from MacPorts.  Tested with both
  `make` (GNU Make from Apple) and `bsdmake` (from MacPorts).
* This also makes it possible to compile lz4jsoncat on NetBSD
  with archivers/lz4 installed from pkgsrc.  Tested with both
  `make` (NetBSD make) as well as `gmake` (from pkgsrc).
* This likely also fixes compilation issues on FreeBSD and OpenBSD,
  as per https://github.com/andikleen/lz4json/issues/1 and
  http://ports.openbsd.su/archivers/lz4json.
* Make it possible to specify LOCALBASE w/ `env LOCALBASE=/path make`
  in case you have some other paths where lz4 is installed.

Fixes the following error message:

```
Package liblz4 was not found in the pkg-config search path.
Perhaps you should add the directory containing `liblz4.pc'
to the PKG_CONFIG_PATH environment variable
No package 'liblz4' found
cc -g -O2 -Wall    lz4jsoncat.c   -o lz4jsoncat
lz4jsoncat.c:43:10: fatal error: 'lz4.h' file not found
         ^
1 error generated.
make: *** [lz4jsoncat] Error 1
```

As well as the following subsequent one once the above is fixed:

```
cc -g -O2 -Wall -I/usr/local/include -I/opt/local/include    lz4jsoncat.c    -o lz4jsoncat
Undefined symbols for architecture x86_64:
  "_LZ4_decompress_safe_partial", referenced from:
      _main in lz4jsoncat-af9c54.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [lz4jsoncat] Error 1
```

Plus the following, too:

```
cc -g -O2 -Wall -I/usr/local/include -I/opt/local/include    lz4jsoncat.c  -llz4     -o lz4jsoncat
ld: library not found for -llz4
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [lz4jsoncat] Error 1
```
